### PR TITLE
default to the upstream registry to "public.ecr.aws"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,8 +13,10 @@ options:
       It is strongly recommended that you use 'juju trust' instead, if available.
     type: string
     default: ""
+
   image-registry:
     type: string
+    default: "public.ecr.aws"
     description: |
       Source registry of metrics server images.
 
@@ -24,7 +26,7 @@ options:
       If unset, the manifests will use the image registry from the kube-control relation
 
       example)
-        juju config kubernetes-metrics-server image-registry='rocks.canonical.com:443/cdk'
+        juju config kubernetes-metrics-server image-registry=''
 
         juju config kubernetes-metrics-server --reset image-registry
 


### PR DESCRIPTION
Make the upstream registry the default, rather than using what's defined by the kube-control relation the default