### PR TITLE
Fix relation names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ juju config kubernetes-control-plane allow-privileged=true
 juju deploy aws-integrator --trust
 juju deploy aws-k8s-storage
 
-juju relate aws-k8s-storage:certificates     easyrsa
-juju relate aws-k8s-storage:kube-control     kubernetes-control-plane
-juju relate aws-k8s-storage                  aws-integrator:clients
-juju relate kubernetes-control-plane         aws-integrator:clients
-juju relate kubernetes-worker                aws-integrator:clients
+juju relate aws-k8s-storage:certificates     easyrsa:client
+juju relate aws-k8s-storage:kube-control     kubernetes-control-plane:kube-control
+juju relate aws-k8s-storage:aws-integration  aws-integrator:aws
+juju relate kubernetes-control-plane:aws     aws-integrator:aws
+juju relate kubernetes-worker:aws            aws-integrator:aws
 
 ##  wait for the kubernetes-control-plane to be active/idle
 kubectl describe nodes |egrep "Taints:|Name:|Provider"


### PR DESCRIPTION
The aws-integrator:clients relation doesn't exist. I pulled the relation names from the [integration test overlay](https://github.com/charmed-kubernetes/aws-k8s-storage/blob/f48e25e02843c3438748adcdc3bc960c9fb89756/tests/data/charm.yaml#L17-L29) which I think should be correct.