### PR TITLE
[LP#1999427] handle ManifestClientErrors which cause hiccups in install and update-status

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
 
   charmcraft-build:
     name: Build Charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -36,6 +36,12 @@ jobs:
           sudo lxc network set lxdbr0 ipv6.address none
           sudo usermod -a -G lxd $USER
           sg lxd -c 'lxc version'
+      - name: Remove Docker
+        run: |
+          # https://github.com/canonical/lxd-cloud/blob/f20a64a8af42485440dcbfd370faf14137d2f349/test/includes/lxd.sh#L13-L23
+          sudo rm -rf /etc/docker
+          sudo apt-get purge moby-buildx moby-engine moby-cli moby-compose moby-containerd moby-runc -y
+          sudo iptables -P FORWARD ACCEPT
       - name: Install Charmcraft
         run: |
           sudo snap install charmcraft --classic --channel=latest/stable

--- a/actions.yaml
+++ b/actions.yaml
@@ -26,3 +26,20 @@ scrub-resources:
       default: ""
       description: |
         Space separated list of kubernetes resource types to filter scrubbing   
+sync-resources:
+  description: |
+    Add kubernetes resources which should be created by this charm which aren't
+    present within the cluster.
+  params:
+    controller:
+      type: string
+      default: ""
+      description: |
+        Filter list based on "storage" manifests.
+    resources:
+      type: string
+      default: ""
+      description: |
+        Space separated list of kubernetes resource types
+        to use a filter during the sync. This helps limit
+        which missing resources are applied.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ops>=1.3.0,<2.0.0
 lightkube>=0.10.1,<1.0.0
 pydantic
 pyyaml
-git+https://github.com/canonical/ops-lib-manifest.git@602eb96dcfa54269505923b28d861771879c703d
+git+https://github.com/canonical/ops-lib-manifest.git@0929a0d1483b927783c75cdc5ebe6694b7f26d88
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -181,11 +181,12 @@ class AwsK8sStorageCharm(CharmBase):
             try:
                 controller.apply_manifests()
             except ManifestClientError:
+                self.unit.status = WaitingStatus("Waiting for kube-apiserver")
                 event.defer()
                 return
         self.stored.deployed = True
 
-    def _cleanup(self, _event):
+    def _cleanup(self, event):
         if self.stored.config_hash:
             self.unit.status = MaintenanceStatus("Cleaning up AWS Storage")
             for controller in self.collector.manifests.values():

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.interface_kube_control import KubeControlRequirer
 from ops.main import main
-from ops.manifests import Collector
+from ops.manifests import Collector, ManifestClientError
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
 from config import CharmConfig
@@ -60,6 +60,7 @@ class AwsK8sStorageCharm(CharmBase):
         self.framework.observe(self.on.list_versions_action, self._list_versions)
         self.framework.observe(self.on.list_resources_action, self._list_resources)
         self.framework.observe(self.on.scrub_resources_action, self._scrub_resources)
+        self.framework.observe(self.on.sync_resources_action, self._sync_resources)
         self.framework.observe(self.on.update_status, self._update_status)
 
         self.framework.observe(self.on.install, self._install_or_upgrade)
@@ -80,6 +81,11 @@ class AwsK8sStorageCharm(CharmBase):
         resources = event.params.get("resources", "")
         return self.collector.scrub_resources(event, manifests, resources)
 
+    def _sync_resources(self, event):
+        manifests = event.params.get("controller", "")
+        resources = event.params.get("resources", "")
+        return self.collector.apply_missing_resources(event, manifests, resources)
+
     def _update_status(self, _):
         if not self.stored.deployed:
             return
@@ -92,7 +98,7 @@ class AwsK8sStorageCharm(CharmBase):
             self.unit.set_workload_version(self.collector.short_version)
             self.app.status = ActiveStatus(self.collector.long_version)
 
-    def _kube_control(self, event=None):
+    def _kube_control(self, event):
         self.kube_control.set_auth_request(self.unit.name)
         return self._merge_config(event)
 
@@ -136,7 +142,7 @@ class AwsK8sStorageCharm(CharmBase):
             return False
         return True
 
-    def _merge_config(self, event=None):
+    def _merge_config(self, event):
         if not self._check_certificates(event):
             return
 
@@ -160,15 +166,19 @@ class AwsK8sStorageCharm(CharmBase):
 
         self.stored.config_hash = new_hash
         self.stored.deployed = False
-        self._install_or_upgrade()
+        self._install_or_upgrade(event)
 
-    def _install_or_upgrade(self, _event=None):
+    def _install_or_upgrade(self, event):
         if not self.stored.config_hash:
             return
         self.unit.status = MaintenanceStatus("Deploying AWS Storage")
         self.unit.set_workload_version("")
         for controller in self.collector.manifests.values():
-            controller.apply_manifests()
+            try:
+                controller.apply_manifests()
+            except ManifestClientError:
+                event.defer()
+                return
         self.stored.deployed = True
 
     def _cleanup(self, _event):

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg \
       --skip {[vars]cov_path} \


### PR DESCRIPTION
[LP#1999427](https://bugs.launchpad.net/bugs/1999427)

* adding sync-resource action which was inexplicably missing
* use 1.0.0 version of ops-lib-manifest