### PR TITLE
sync-resources action should mark charm deployed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ ops>=1.3.0,<2.0.0
 lightkube>=0.10.1,<1.0.0
 pydantic
 pyyaml
-git+https://github.com/canonical/ops-lib-manifest.git@a02d83af8febeed39b7324b0247368cfc7105d73
+ops.manifest>=1.1.0,<2.0.0
 git+https://github.com/charmed-kubernetes/interface-kube-control.git@6dd289d1c795fdeda1bed17873b8d6562227c829#subdirectory=ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -89,6 +89,8 @@ class AwsK8sStorageCharm(CharmBase):
         except ManifestClientError:
             msg = "Failed to apply missing resources. API Server unavailable."
             event.set_results({"result": msg})
+        else:
+            self.stored.deployed = True
 
     def _update_status(self, _):
         if not self.stored.deployed:

--- a/upstream/update.py
+++ b/upstream/update.py
@@ -80,7 +80,7 @@ class Release:
 
     def __lt__(self, other) -> bool:
         """Compare version numbers."""
-        a, b, = (
+        a, b = (
             self.name[1:],
             other.name[1:],
         )


### PR DESCRIPTION
* [LP#2010233](https://bugs.launchpad.net/bugs/2010233) 
   -- update to newer ops.manifest to prevent multiple-rewrite of configurable properties
* [LP#2009965](https://bugs.launchpad.net/bugs/2009965)
   -- set charm as deployed after successful sync-manifest action
