### PR TITLE
Correct ubuntu bases used by the charm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - call-inclusive-naming-check
     with:
       with-uv: true
-      python: "['3.10', '3.12']"      
+      python: "['3.10', '3.12']"
 
   charmcraft-channel:
     runs-on: ubuntu-24.04

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -132,28 +132,28 @@ requires:
 # Architectures based on supported arch's in upstream
 # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/Makefile#L39
 bases:
-  - build-on:
-    - name: "ubuntu"
-      channel: "22.04"
-      architectures: ["amd64"]
-    run-on:
-    - name: "ubuntu"
-      channel: "24.04"
-      architectures:
-        - amd64
-        - arm64
-    - name: "ubuntu"
-      channel: "24.04"
-      architectures:
-        - amd64
-        - arm64
+- build-on:
+  - name: "ubuntu"
+    channel: "22.04"
+    architectures: ["amd64"]
+  run-on:
+  - name: "ubuntu"
+    channel: "22.04"
+    architectures:
+    - amd64
+    - arm64
+  - name: "ubuntu"
+    channel: "24.04"
+    architectures:
+    - amd64
+    - arm64
 parts:
   charm:
     source: .
     plugin: charm
     override-build: |
       craftctl default
-      git -C $CRAFT_PROJECT_DIR rev-parse --short HEAD > version
+      git -C $CRAFT_PROJECT_DIR rev-parse --short HEAD > $CRAFT_PRIME/version
     build-packages:
     - git
     charm-python-packages:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 [project]
 name="aws-k8s-storage"
 version = "0.0.0"
-description = "Charmed Operators for AWS Cloud Provider"
+description = "Charmed Operators for AWS K8s Storage"
 readme = "README.md"
 requires-python = ">=3.10"
 


### PR DESCRIPTION
Correct bases to remove the duplicates `24.04` intended to be `22.04`